### PR TITLE
feat: support trailing slash

### DIFF
--- a/buildurl/builder.py
+++ b/buildurl/builder.py
@@ -29,9 +29,11 @@ class BuildURL:
         # part of `path`, and not isolated
         self.scheme: str = purl.scheme
         self.netloc: str = purl.netloc
-        self.path_list: PathList = list()
+        self._path_list: PathList = list()
         self.query_dict: QueryDict = dict()
         self.fragment: str = purl.fragment
+
+        self.trailing_slash: bool = False
 
         path_str: str = purl.path
         if path_str:
@@ -74,7 +76,7 @@ class BuildURL:
             https://example.com/test/more/paths
             >>> url.add_path("/again/and/again/")
             >>> print(url.get)
-            https://example.com/test/more/paths/again/and/again
+            https://example.com/test/more/paths/again/and/again/
         """
 
         path_list = list()
@@ -85,9 +87,11 @@ class BuildURL:
         else:
             raise AttributeError
 
+        if len(path_list):
+            self.trailing_slash = path_list[-1] == ""
         path_list = [p for p in path_list if p]  # Remove empty strings
 
-        self.path_list.extend(path_list)
+        self._path_list.extend(path_list)
 
     def add_query(self, query: Query) -> None:
         """Add a query argument.
@@ -122,12 +126,15 @@ class BuildURL:
     @property
     def path(self) -> str:
         """Path string."""
-        return "/".join(self.path_list)
+        path = "/".join(self._path_list)
+        if self.trailing_slash:
+            path += "/"
+        return path
 
     @path.setter
     def path(self, path: Optional[Path]):
         """Replace current path."""
-        self.path_list = list()
+        self._path_list = list()
         if path is not None:
             self.add_path(path)
 
@@ -181,7 +188,7 @@ class BuildURL:
             https://example.com/test/more/paths
             >>> url /= "/again/and/again/"
             >>> print(url.get)
-            https://example.com/test/more/paths/again/and/again
+            https://example.com/test/more/paths/again/and/again/
         """
 
         self.add_path(path)

--- a/tests/test_buildurl.py
+++ b/tests/test_buildurl.py
@@ -57,11 +57,23 @@ def test_path():
     url.path = ["still", "testing"]
     assert url.get == "https://example.com/still/testing"
     url.path = "/once/more/"
-    assert url.get == "https://example.com/once/more"
-    url.path_list = ["again", "and", "again"]
+    assert url.get == "https://example.com/once/more/"
+    url.path = ["again", "and", "again"]
     assert url.get == "https://example.com/again/and/again"
     url.path = None
     assert url.get == "https://example.com"
+
+    url = BuildURL("https://example.com/")
+    assert url.get == "https://example.com/"
+    url /= "path"
+    assert url.get == "https://example.com/path"
+    url /= "another//path"
+    assert url.get == "https://example.com/path/another/path"
+    url /= "/again/"
+    assert url.get == "https://example.com/path/another/path/again/"
+
+    url = BuildURL("https://example.com/folder/")
+    assert url.get == "https://example.com/folder/"
 
 
 def test_query():


### PR DESCRIPTION
Closes #8

BREAKING CHANGE: Removed public `path_list` attribute, should now be accessed through `path`.
BREAKING CHANGE: Trailing slash no longer removed.